### PR TITLE
remove duplicate / in setup directory

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -32,7 +32,7 @@ for url in ${urls[@]}; do
 done
 
 PYTHON_PATH="$(which python3)"
-SETUP_DIR="${WORKING_DIR}/setup/"
+SETUP_DIR="${WORKING_DIR}/setup"
 DOWNLOAD_SCRIPT_PY="${SETUP_DIR}/download.py"
 
 # Install gdown if not installed, without this package globaly the installation will fail


### PR DESCRIPTION
This change removes the duplicate slashes in the setup script, this will lead to the following error
```
django_bgRemoverML/setup//download.py, not found!
```
I removed one of the / from line 25. Alternatively you could remove a slash from line 36. I chose to remove it from line 25 to make the code more understandable compared to the following

```
SETUP_DIR="${WORKING_DIR}/setup/"
DOWNLOAD_SCRIPT_PY="${SETUP_DIR}download.py"
```